### PR TITLE
Ajuste na URL de logout

### DIFF
--- a/src/GovBr.php
+++ b/src/GovBr.php
@@ -145,7 +145,7 @@ class GovBr extends AbstractProvider
             throw new UnexpectedValueException("Parâmetro redirectUriLogout não foi definido");
         }
 
-        $query  = $this->buildQueryString(['post_logout_redirect_uri' => $this->redirectUriLogout]);
+        $query  = $this->buildQueryString(['client_id'=>$this->clientId, 'post_logout_redirect_uri' => $this->redirectUriLogout]);
         return $this->appendQuery($this->urlLogout, $query);
     }
 


### PR DESCRIPTION
Faz-se necessário adicionar o client_id para que o sistema do GovBR redirecione para a URL desejada